### PR TITLE
Fix ReadWriteLock `writeMutex` issue

### DIFF
--- a/lib/ReadWriteLock.js
+++ b/lib/ReadWriteLock.js
@@ -25,13 +25,7 @@ module.exports = ReadWriteLock;
  */
 function ReadWriteLock(client, basePath) {
   var readLockDriver = new ReadLockDriver(this);
-
-  /**
-   * Write mutex.
-   *
-   * @type {Lock}
-   */
-  this.writeMutex = new Lock(client, basePath, WRITE_LOCK_NAME);
+  var writeLockDriver = new SortingLockDriver();
 
 
   /**
@@ -41,6 +35,15 @@ function ReadWriteLock(client, basePath) {
    */
   this.readMutex = new Lock(client, basePath, READ_LOCK_NAME, readLockDriver);
   this.readMutex.setMaxLeases(Infinity);
+
+
+  /**
+   * Write mutex.
+   *
+   * @type {Lock}
+   */
+  this.writeMutex = new Lock(client, basePath, WRITE_LOCK_NAME,
+    writeLockDriver);
 }
 
 
@@ -132,7 +135,8 @@ util.inherits(ReadLockDriver, SortingLockDriver);
 /**
  * @see {@link LockDriver#getsTheLock}
  */
-ReadLockDriver.prototype.getsTheLock = function getsTheLock(list, sequenceNodeName) {
+ReadLockDriver.prototype.getsTheLock = function getsTheLock(list,
+                                                            sequenceNodeName) {
   if (this.readWriteLock.writeMutex.isOwner()) {
     return {
       hasLock: true


### PR DESCRIPTION
`ReadWriteLock#writeMutex` had default `LockDriver` which caused wrong sorting of participating nodes list. In some situations this issue can cause dead locking.