### PR TITLE
Fix bug when callback is called twice because of timer set twice or more times

### DIFF
--- a/lib/Lock.js
+++ b/lib/Lock.js
@@ -192,7 +192,8 @@ function attemptLock(lock, timeout, callback) {
     }
 
     var watchPath = utils.join(lock.basePath, result.watchPath);
-    lock.client.zk.getData(watchPath, watcher, afterGetData);
+    lock.client.getData().usingWatcher(watcher).forPath(watchPath,
+      afterGetData);
 
     setTimer();
   }
@@ -217,6 +218,10 @@ function attemptLock(lock, timeout, callback) {
   }
 
   function setTimer() {
+    if (timerId) {
+      return;
+    }
+
     if (timeout >= 0) {
       timeout -= Date.now() - start;
 
@@ -235,7 +240,7 @@ function attemptLock(lock, timeout, callback) {
   function exit(err, path) {
     if (timerId) {
       clearTimeout(timerId);
-      timerId = null;
+      timerId = -1;
     }
 
     var cb = callback;
@@ -280,7 +285,8 @@ function createNode(lock, callback) {
   var nodePath = utils.join(lock.basePath, lock.lockName);
   var client = lock.client;
 
-  client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL_SEQUENTIAL).forPath(nodePath, callback);
+  client.create().creatingParentsIfNeeded().withMode(CreateMode.EPHEMERAL_SEQUENTIAL).forPath(nodePath,
+    callback);
 }
 
 
@@ -328,7 +334,7 @@ Lock.prototype.destroy = function destroy(callback) {
  * @param {Function} callback Callback function: `(err, list)`
  */
 function getSortedChildren(lock, callback) {
-  lock.client.zk.getChildren(lock.basePath, afterGetChildren);
+  lock.client.getChildren().forPath(lock.basePath, afterGetChildren);
 
   function afterGetChildren(err, list) {
     if (err) {


### PR DESCRIPTION
There may be a situation when Lock#acquire() executes getData() and result is NO_NODE error which makes it call getChildren() and enter the same procedure again calling setTimer() twice or more times. In last mentioned function there was no check for already existing timer. That's the cause of the bug.